### PR TITLE
Added a ordinal value conversion

### DIFF
--- a/bangla/__init__.py
+++ b/bangla/__init__.py
@@ -1,36 +1,99 @@
 # -*- coding: utf-8 -*-
 import datetime
 
-bangla_number = ['০', '১','২', '৩','৪',
-                 '৫','৬', '৭', '৮', '৯']
+bangla_number = ["০", "১", "২", "৩", "৪", "৫", "৬", "৭", "৮", "৯"]
 
-english_number = ['0', '1', '2', '3', '4',
-                  '5', '6', '7', '8', '9']
+english_number = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
 
-greg_equivalent_bangla_months = ["পৌষ", "মাঘ", "ফাল্গুন", "চৈত্র", "বৈশাখ", "জ্যৈষ্ঠ",
-                     "আষাঢ়", "শ্রাবণ", "ভাদ্র", "আশ্বিন", "কার্তিক", "অগ্রহায়ণ"]
+greg_equivalent_bangla_months = [
+    "পৌষ",
+    "মাঘ",
+    "ফাল্গুন",
+    "চৈত্র",
+    "বৈশাখ",
+    "জ্যৈষ্ঠ",
+    "আষাঢ়",
+    "শ্রাবণ",
+    "ভাদ্র",
+    "আশ্বিন",
+    "কার্তিক",
+    "অগ্রহায়ণ",
+]
 
-python_bangla_weekdays = ["সোমবার", "মঙ্গলবার", "বুধবার",
-                       "বৃহস্পতিবার", "শুক্রবার", "শনিবার", "রবিবার"]
+python_bangla_weekdays = [
+    "সোমবার",
+    "মঙ্গলবার",
+    "বুধবার",
+    "বৃহস্পতিবার",
+    "শুক্রবার",
+    "শনিবার",
+    "রবিবার",
+]
 
-greg_equivalent_bangla_seasons = ["শীত", "বসন্ত", "গ্রীষ্ম",
-                      "বর্ষা", "শরৎ", "হেমন্ত"]
+greg_equivalent_bangla_seasons = ["শীত", "বসন্ত", "গ্রীষ্ম", "বর্ষা", "শরৎ", "হেমন্ত"]
 
-greg_equivalent_last_day_of_bangla_months =  [13, 12, 14, 13, 14, 14,
-                                              15, 15, 15, 15, 14, 14]
+bengali_ordinals = [
+    "পহেলা",
+    "দোসরা",
+    "তেসরা",
+    "চৌঠা",
+    "পাঁচই",
+    "ছয়ই",
+    "সাতই",
+    "আটই",
+    "নয়ই",
+    "দশই",
+    "এগারোই",
+    "বারোই",
+    "তেরোই",
+    "চৌদ্দই",
+    "পনেরোই",
+    "ষোলোই",
+    "সতেরোই",
+    "আঠারোই",
+    "ঊনিশে",
+    "বিশে",
+    "একুশে",
+    "বাইশে",
+    "তেইশে",
+    "চব্বিশে",
+    "পঁচিশে",
+    "ছাব্বিশে",
+    "সাতাশে",
+    "আঠাশে",
+    "ঊনত্রিশে",
+    "ত্রিশে",
+    "একত্রিশে",
+]
 
-total_days_in_bangla_months = [30, 30, 30, 30, 31, 31,
-                               31, 31, 31, 30, 30, 30]
+greg_equivalent_last_day_of_bangla_months = [
+    13,
+    12,
+    14,
+    13,
+    14,
+    14,
+    15,
+    15,
+    15,
+    15,
+    14,
+    14,
+]
+
+total_days_in_bangla_months = [30, 30, 30, 30, 31, 31, 31, 31, 31, 30, 30, 30]
 
 greg_equivalent_leap_year_index_in_bangla_months = 2
+
 
 def is_leap_year(passed_year):
     if passed_year % 400 == 0:
         return 1
-    elif passed_year%4 == 0 and passed_year%100 != 0:
+    elif passed_year % 4 == 0 and passed_year % 100 != 0:
         return 1
     else:
         return 0
+
 
 def get_bangla_year(passed_date, passed_month, passed_year):
     if passed_month > 3:
@@ -41,21 +104,44 @@ def get_bangla_year(passed_date, passed_month, passed_year):
         bangla_year = passed_year - 594
     return bangla_year
 
+
 def get_bangla_weekday(passed_date, passed_month, passed_year):
     current_date_object = datetime.datetime(passed_year, passed_month, passed_date)
     bangla_weekday = python_bangla_weekdays[current_date_object.weekday()]
     return bangla_weekday
 
-def convert_english_digit_to_bangla_digit(original):
+
+def _convert_digits(original, source_digits, target_digits):
     converted = ""
     for character in str(original):
-        if character in english_number:
-            converted+=bangla_number[english_number.index(character)]
+        if character in source_digits:
+            converted += target_digits[source_digits.index(character)]
         else:
-            converted+=character
+            converted += character
     return converted
 
-def get_date(passed_date=None, passed_month=None, passed_year=None):
+
+def convert_english_digit_to_bangla_digit(original):
+    return _convert_digits(original, english_number, bangla_number)
+
+
+def convert_bangla_digit_to_english_digit(original):
+    return _convert_digits(original, bangla_number, english_number)
+
+
+def convert_to_ordinal(day: str) -> str:
+    d = int(convert_bangla_digit_to_english_digit(day))
+    if d <= len(bengali_ordinals):
+        return bengali_ordinals[d - 1]
+    return ""
+
+
+def get_date(
+    passed_date=None, passed_month=None, passed_year=None, ordinal: bool | None = False
+):
+    """No Param : Get Current Date
+    ordinal : if `None` or `False` doesn't return ordinal; if true, provides ordinal representation of the day
+    """
     if passed_date == None and passed_month == None and passed_year == None:
         current_date_object = datetime.date.today()
         passed_year = current_date_object.year
@@ -66,14 +152,23 @@ def get_date(passed_date=None, passed_month=None, passed_year=None):
     bangla_year = get_bangla_year(passed_date, passed_month, passed_year)
     if passed_date <= greg_equivalent_last_day_of_bangla_months[passed_month]:
         total_days_in_current_bangla_month = total_days_in_bangla_months[passed_month]
-        if passed_month == greg_equivalent_leap_year_index_in_bangla_months and is_leap_year(passed_year) == 1:
+        if (
+            passed_month == greg_equivalent_leap_year_index_in_bangla_months
+            and is_leap_year(passed_year) == 1
+        ):
             total_days_in_current_bangla_month += 1
-        bangla_date = total_days_in_current_bangla_month + passed_date - greg_equivalent_last_day_of_bangla_months[passed_month]
+        bangla_date = (
+            total_days_in_current_bangla_month
+            + passed_date
+            - greg_equivalent_last_day_of_bangla_months[passed_month]
+        )
         bangla_month_index = passed_month
         bangla_month = greg_equivalent_bangla_months[bangla_month_index]
     else:
-        bangla_date = passed_date - greg_equivalent_last_day_of_bangla_months[passed_month]
-        bangla_month_index = (passed_month+1)%12
+        bangla_date = (
+            passed_date - greg_equivalent_last_day_of_bangla_months[passed_month]
+        )
+        bangla_month_index = (passed_month + 1) % 12
         bangla_month = greg_equivalent_bangla_months[bangla_month_index]
 
     bangla_season = greg_equivalent_bangla_seasons[bangla_month_index // 2]
@@ -83,7 +178,12 @@ def get_date(passed_date=None, passed_month=None, passed_year=None):
         "month": convert_english_digit_to_bangla_digit(bangla_month),
         "year": convert_english_digit_to_bangla_digit(bangla_year),
         "season": convert_english_digit_to_bangla_digit(bangla_season),
-        "weekday": convert_english_digit_to_bangla_digit(bangla_weekday)
+        "weekday": convert_english_digit_to_bangla_digit(bangla_weekday),
     }
+
+    if ordinal:
+        bangla_date_month_year_season["ordinal"] = convert_to_ordinal(
+            bangla_date_month_year_season["date"]
+        )
 
     return bangla_date_month_year_season

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1,15 +1,14 @@
 # -*- coding: utf-8 -*-
 import unittest
-import datetime
-import time
 import os
 import sys
-BASEDIR = os.path.abspath(os.path.join(
-                          os.path.dirname(os.path.abspath(__file__)),
-                          ".."))
+
+BASEDIR = os.path.abspath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
+)
 sys.path.insert(0, BASEDIR)
 import bangla
-import locale
+
 
 class TestBangla(unittest.TestCase):
     def test_is_leap_year(self):
@@ -21,30 +20,78 @@ class TestBangla(unittest.TestCase):
         self.assertEqual(is_leap_year_flag, 0)
 
     def test_get_bangla_year(self):
-        res = bangla.get_bangla_year(22,6,2017)
+        res = bangla.get_bangla_year(22, 6, 2017)
         self.assertEqual(res, 1424)
-        res = bangla.get_bangla_year(1,1,2017)
+        res = bangla.get_bangla_year(1, 1, 2017)
         self.assertEqual(res, 1423)
-        res = bangla.get_bangla_year(22,3,2017)
+        res = bangla.get_bangla_year(22, 3, 2017)
         self.assertEqual(res, 1424)
 
     def test_get_bangla_weekday(self):
-        res = bangla.get_bangla_weekday(22,6,2017)
+        res = bangla.get_bangla_weekday(22, 6, 2017)
         self.assertEqual(res, "বৃহস্পতিবার")
 
     def test_convert_english_digit_to_bangla_digit(self):
         res = bangla.convert_english_digit_to_bangla_digit("123456")
         self.assertEqual(res, "১২৩৪৫৬")
 
+    def test_convert_to_ordinal(self):
+        res = bangla.convert_to_ordinal("২১")
+        self.assertEqual(res, "একুশে")
+
+        res = bangla.convert_to_ordinal("21")
+        self.assertEqual(res, "একুশে")
+
     def test_get_date(self):
-        res = bangla.get_date(22,6,2017)
-        self.assertEqual(res, {'date': '৮', 'month': 'আষাঢ়', 'year': '১৪২৪', 'season': 'বর্ষা', 'weekday': 'বৃহস্পতিবার'})
-        res = bangla.get_date(7,6,2017)
-        self.assertEqual(res, {'date': '২৪', 'month': 'জ্যৈষ্ঠ', 'year': '১৪২৪', 'season': 'গ্রীষ্ম', 'weekday': 'বুধবার'})
-        res = bangla.get_date(7,3,2016)
-        self.assertEqual(res, {'date': '২৪', 'month': 'ফাল্গুন', 'year': '১৪২২', 'season': 'বসন্ত', 'weekday': 'সোমবার'})
+        res = bangla.get_date(22, 6, 2017)
+        self.assertEqual(
+            res,
+            {
+                "date": "৮",
+                "month": "আষাঢ়",
+                "year": "১৪২৪",
+                "season": "বর্ষা",
+                "weekday": "বৃহস্পতিবার",
+            },
+        )
+        res = bangla.get_date(7, 6, 2017)
+        self.assertEqual(
+            res,
+            {
+                "date": "২৪",
+                "month": "জ্যৈষ্ঠ",
+                "year": "১৪২৪",
+                "season": "গ্রীষ্ম",
+                "weekday": "বুধবার",
+            },
+        )
+        res = bangla.get_date(7, 3, 2016)
+        self.assertEqual(
+            res,
+            {
+                "date": "২৪",
+                "month": "ফাল্গুন",
+                "year": "১৪২২",
+                "season": "বসন্ত",
+                "weekday": "সোমবার",
+            },
+        )
+        res = bangla.get_date(7, 3, 2016, ordinal=True)
+        self.assertEqual(
+            res,
+            {
+                "date": "২৪",
+                "month": "ফাল্গুন",
+                "year": "১৪২২",
+                "season": "বসন্ত",
+                "weekday": "সোমবার",
+                "ordinal": "চব্বিশে",
+            },
+        )
+
         res = bangla.get_date()
         self.assertIsInstance(res, dict, "The return type is not a dictionary")
-        
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Added a conversion mechanism for day value to ordinal values such as  

|english|bangla|ordinal|
|---|---|---|
|1|১|পহেলা|
|2|২|দোসরা|
|3|৩|তেসরা|

- Added a new parameter, `ordinal`. if True, it adds 'ordinal' key in the return dictionary.
```raw
Output: 
{
    'date': '৮',
    ... ...
    ... ...
    'ordinal': 'আটই'
}
```
- Added a ordinal conversion API `convert_to_ordinal(str)`
works for both English and Bangla numerics till 31