### PR TITLE
Add Python3.7+ compatibility

### DIFF
--- a/bangla/__init__.py
+++ b/bangla/__init__.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import datetime
 
 bangla_number = ["০", "১", "২", "৩", "৪", "৫", "৬", "৭", "৮", "৯"]


### PR DESCRIPTION
- Fix `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType' ` in type hints for Python >= 3.7, <3.10.